### PR TITLE
Fix spelling of 'rogue'

### DIFF
--- a/01_web_ui/README.md
+++ b/01_web_ui/README.md
@@ -1,1 +1,1 @@
-Code for the [Haskell rougelike blog post](http://www.andrevdm.com/posts/2018-04-02-haskell-rogue-like.html)
+Code for the [Haskell roguelike blog post](http://www.andrevdm.com/posts/2018-04-02-haskell-rogue-like.html)

--- a/02_tileset/README.md
+++ b/02_tileset/README.md
@@ -1,1 +1,1 @@
-Code for the [Haskell rougelike blog post](http://www.andrevdm.com/posts/2018-04-02-haskell-rogue-like.html)
+Code for the [Haskell roguelike blog post](http://www.andrevdm.com/posts/2018-04-02-haskell-rogue-like.html)

--- a/03_tiles/README.md
+++ b/03_tiles/README.md
@@ -1,1 +1,1 @@
-Code for the [Haskell rougelike blog post](http://www.andrevdm.com/posts/2018-04-02-haskell-rogue-like.html)
+Code for the [Haskell roguelike blog post](http://www.andrevdm.com/posts/2018-04-02-haskell-rogue-like.html)

--- a/04_load_map/README.md
+++ b/04_load_map/README.md
@@ -1,1 +1,1 @@
-Code for the [Haskell rougelike blog post](http://www.andrevdm.com/posts/2018-04-02-haskell-rogue-like.html)
+Code for the [Haskell roguelike blog post](http://www.andrevdm.com/posts/2018-04-02-haskell-rogue-like.html)

--- a/05_actors/README.md
+++ b/05_actors/README.md
@@ -1,1 +1,1 @@
-Code for the [Haskell rougelike blog post](http://www.andrevdm.com/posts/2018-04-02-haskell-rogue-like.html)
+Code for the [Haskell roguelike blog post](http://www.andrevdm.com/posts/2018-04-02-haskell-rogue-like.html)

--- a/06_moving/README.md
+++ b/06_moving/README.md
@@ -1,1 +1,1 @@
-Code for the [Haskell rougelike blog post](http://www.andrevdm.com/posts/2018-04-02-haskell-rogue-like.html)
+Code for the [Haskell roguelike blog post](http://www.andrevdm.com/posts/2018-04-02-haskell-rogue-like.html)

--- a/07_collisions/README.md
+++ b/07_collisions/README.md
@@ -1,1 +1,1 @@
-Code for the [Haskell rougelike blog post](http://www.andrevdm.com/posts/2018-04-02-haskell-rogue-like.html)
+Code for the [Haskell roguelike blog post](http://www.andrevdm.com/posts/2018-04-02-haskell-rogue-like.html)

--- a/08_layers/README.md
+++ b/08_layers/README.md
@@ -1,1 +1,1 @@
-Code for the [Haskell rougelike blog post](http://www.andrevdm.com/posts/2018-04-02-haskell-rogue-like.html)
+Code for the [Haskell roguelike blog post](http://www.andrevdm.com/posts/2018-04-02-haskell-rogue-like.html)

--- a/09_viewport_scroll/README.md
+++ b/09_viewport_scroll/README.md
@@ -1,1 +1,1 @@
-Code for the [Haskell rougelike blog post](http://www.andrevdm.com/posts/2018-04-02-haskell-rogue-like.html)
+Code for the [Haskell roguelike blog post](http://www.andrevdm.com/posts/2018-04-02-haskell-rogue-like.html)

--- a/10_fov/README.md
+++ b/10_fov/README.md
@@ -1,1 +1,1 @@
-Code for the [Haskell rougelike blog post](http://www.andrevdm.com/posts/2018-04-02-haskell-rogue-like.html)
+Code for the [Haskell roguelike blog post](http://www.andrevdm.com/posts/2018-04-02-haskell-rogue-like.html)

--- a/11_sticky_light/README.md
+++ b/11_sticky_light/README.md
@@ -1,1 +1,1 @@
-Code for the [Haskell rougelike blog post](http://www.andrevdm.com/posts/2018-04-02-haskell-rogue-like.html)
+Code for the [Haskell roguelike blog post](http://www.andrevdm.com/posts/2018-04-02-haskell-rogue-like.html)

--- a/12_energy/README.md
+++ b/12_energy/README.md
@@ -1,1 +1,1 @@
-Code for the [Haskell rougelike blog post](http://www.andrevdm.com/posts/2018-04-02-haskell-rogue-like.html)
+Code for the [Haskell roguelike blog post](http://www.andrevdm.com/posts/2018-04-02-haskell-rogue-like.html)

--- a/13_utility/README.md
+++ b/13_utility/README.md
@@ -1,1 +1,1 @@
-Code for the [Haskell rougelike blog post](http://www.andrevdm.com/posts/2018-04-02-haskell-rogue-like.html)
+Code for the [Haskell roguelike blog post](http://www.andrevdm.com/posts/2018-04-02-haskell-rogue-like.html)

--- a/14_utility_annotate/README.md
+++ b/14_utility_annotate/README.md
@@ -1,1 +1,1 @@
-Code for the [Haskell rougelike blog post](http://www.andrevdm.com/posts/2018-04-02-haskell-rogue-like.html)
+Code for the [Haskell roguelike blog post](http://www.andrevdm.com/posts/2018-04-02-haskell-rogue-like.html)

--- a/15_memory/README.md
+++ b/15_memory/README.md
@@ -1,1 +1,1 @@
-Code for the [Haskell rougelike blog post](http://www.andrevdm.com/posts/2018-04-02-haskell-rogue-like.html)
+Code for the [Haskell roguelike blog post](http://www.andrevdm.com/posts/2018-04-02-haskell-rogue-like.html)

--- a/16_debug/README.md
+++ b/16_debug/README.md
@@ -1,1 +1,1 @@
-Code for the [Haskell rougelike blog post](http://www.andrevdm.com/posts/2018-04-02-haskell-rogue-like.html)
+Code for the [Haskell roguelike blog post](http://www.andrevdm.com/posts/2018-04-02-haskell-rogue-like.html)

--- a/17_levels/README.md
+++ b/17_levels/README.md
@@ -1,1 +1,1 @@
-Code for the [Haskell rougelike blog post](http://www.andrevdm.com/posts/2018-04-02-haskell-rogue-like.html)
+Code for the [Haskell roguelike blog post](http://www.andrevdm.com/posts/2018-04-02-haskell-rogue-like.html)

--- a/18_multi_level/README.md
+++ b/18_multi_level/README.md
@@ -1,1 +1,1 @@
-Code for the [Haskell rougelike blog post](http://www.andrevdm.com/posts/2018-04-02-haskell-rogue-like.html)
+Code for the [Haskell roguelike blog post](http://www.andrevdm.com/posts/2018-04-02-haskell-rogue-like.html)

--- a/19_story/README.md
+++ b/19_story/README.md
@@ -1,1 +1,1 @@
-Code for the [Haskell rougelike blog post](http://www.andrevdm.com/posts/2018-04-02-haskell-rogue-like.html)
+Code for the [Haskell roguelike blog post](http://www.andrevdm.com/posts/2018-04-02-haskell-rogue-like.html)

--- a/20_structure/README.md
+++ b/20_structure/README.md
@@ -1,1 +1,1 @@
-Code for the [Haskell rougelike blog post](http://www.andrevdm.com/posts/2018-04-02-haskell-rogue-like.html)
+Code for the [Haskell roguelike blog post](http://www.andrevdm.com/posts/2018-04-02-haskell-rogue-like.html)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# Haskell rougelike
+# Haskell roguelike
 
-This is the code for the [Haskell rougelike blog post](http://www.andrevdm.com/posts/2018-04-02-haskell-rogue-like.html)
+This is the code for the [Haskell roguelike blog post](http://www.andrevdm.com/posts/2018-04-02-haskell-rogue-like.html)
 
 There are 20 sub-projects each corresponding to one of the blog sub-posts/chapters. The code has the annotations for my [Hakyl include compiler](http://www.andrevdm.com/posts/2018-02-05-hakyll-code-build-include-compiler.html). The source.zip archive has the source without the annotations, this is created/updated when the makefile or `mkDiff.sh` is run.


### PR DESCRIPTION
Fix common misspelling of 'rogue' as 'rouge'.